### PR TITLE
fix: inference resilience + nemotron-3-nano default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - `APP_LLM_MAX_RETRIES` setting (default `3`). Controls how many times an LLM call retries on HTTP 429 or 5xx errors before surfacing the failure. Set to `1` on self-hosted endpoints where retries are unnecessary.
 
 ### Changed
+- Default LLM is now `nvidia/nemotron-3-nano-30b-a3b` (was `meta/llama-3.3-70b-instruct`). The 30B MoE model with 3B active parameters returns faster per call on the hosted catalog and is not subject to the same per-minute quota pressure as the flagship Llama 3.3 70B. Override via `APP_LLM_MODELNAME` for self-hosted NIM endpoints.
+- The deployment notebook's compose-up cell now passes `--build` so the source-built images include all the changes in this release, rather than pulling the pinned NGC image.
 - LLM calls retry transient endpoint failures (HTTP 429 / 5xx) with exponential backoff and jitter.
 - The agent surfaces a rate-limit-specific message ("The model service is rate-limited right now. Please try again in a moment.") when the upstream LLM is throttled, alongside the existing generic rephrase fallbacks for other failure modes.
 - `get_product_name` and the unstructured retriever's query-rewriting step fall back to deterministic logic when their structured-output LLM call fails or returns no usable response. `get_product_name` falls back to token-overlap substring matching against the supplied product list; query rewriting falls back to the original user query unchanged. Retrieval continues either way.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [Unreleased]
+
+### Added
+- `APP_LLM_MAX_RETRIES` setting (default `3`). Controls how many times an LLM call retries on HTTP 429 or 5xx errors before surfacing the failure. Set to `1` on self-hosted endpoints where retries are unnecessary.
+
+### Changed
+- LLM calls retry transient endpoint failures (HTTP 429 / 5xx) with exponential backoff and jitter.
+- The agent surfaces a rate-limit-specific message ("The model service is rate-limited right now. Please try again in a moment.") when the upstream LLM is throttled, alongside the existing generic rephrase fallbacks for other failure modes.
+
 ## [1.1.0] - 2024-12-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Changed
 - LLM calls retry transient endpoint failures (HTTP 429 / 5xx) with exponential backoff and jitter.
 - The agent surfaces a rate-limit-specific message ("The model service is rate-limited right now. Please try again in a moment.") when the upstream LLM is throttled, alongside the existing generic rephrase fallbacks for other failure modes.
+- `get_product_name` and the unstructured retriever's query-rewriting step fall back to deterministic logic when their structured-output LLM call fails or returns no usable response. `get_product_name` falls back to token-overlap substring matching against the supplied product list; query rewriting falls back to the original user query unchanged. Retrieval continues either way.
 
 ## [1.1.0] - 2024-12-12
 

--- a/deploy/ai_virtual_assistant_notebook.ipynb
+++ b/deploy/ai_virtual_assistant_notebook.ipynb
@@ -371,10 +371,7 @@
     "id": "a7387b26"
    },
    "outputs": [],
-   "source": [
-    "%%bash\n",
-    "docker compose -f deploy/compose/docker-compose.yaml up -d"
-   ]
+   "source": "%%bash\ndocker compose -f deploy/compose/docker-compose.yaml up -d --build"
   },
   {
    "cell_type": "code",
@@ -420,12 +417,7 @@
    "cell_type": "markdown",
    "id": "a935841d-e2ba-4509-bc33-c24d26b31f83",
    "metadata": {},
-   "source": [
-    "## Ingest data\n",
-    "\n",
-    "Open the jupyter notebook  \"./ai-virtual-assistant/notebooks/ingest_data.ipynb\" and run through the cells (Shift + Enter) to ingest the structured and unstructured data types.\n",
-    "**NOTE:** The first cell in the ingest_data.ipynb requires you to input the proper IP address of the localhost. If the machine is spun up with a default container on Brev, this ought to be the default Docker IP: 172.17.0.1"
-   ]
+   "source": "## Ingest data\n\nOpen the jupyter notebook [./ai-virtual-assistant/notebooks/ingest_data.ipynb](./ai-virtual-assistant/notebooks/ingest_data.ipynb) and run through the cells (Shift + Enter) to ingest the structured and unstructured data types.\n**NOTE:** The first cell in the ingest_data.ipynb requires you to input the proper IP address of the localhost. If the machine is spun up with a default container on Brev, this ought to be the default Docker IP: 172.17.0.1"
   },
   {
    "cell_type": "markdown",

--- a/deploy/compose/docker-compose.yaml
+++ b/deploy/compose/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
     command: --port 8081 --host 0.0.0.0 --workers 1 --loop asyncio
     environment:
       EXAMPLE_PATH: './src/agent'
-      APP_LLM_MODELNAME: ${APP_LLM_MODELNAME:-"meta/llama-3.3-70b-instruct"}
+      APP_LLM_MODELNAME: ${APP_LLM_MODELNAME:-"nvidia/nemotron-3-nano-30b-a3b"}
       APP_LLM_MODELENGINE: nvidia-ai-endpoints
       APP_LLM_SERVERURL: ${APP_LLM_SERVERURL:-""}
       # Cache name to store user conversation
@@ -43,7 +43,7 @@ services:
       STRUCTURED_RAG_URI: http://structured-retriever:8081
       NVIDIA_API_KEY: ${NVIDIA_API_KEY}
       GRAPH_RECURSION_LIMIT: 20
-      GRAPH_TIMEOUT_IN_SEC: 20 # with meta/llama-3.3-70b-instruct
+      GRAPH_TIMEOUT_IN_SEC: 20 # with nvidia/nemotron-3-nano-30b-a3b
       RETURN_WINDOW_CURRENT_DATE: '2024-10-23' # Leave it empty to get the current date
       RETURN_WINDOW_THRESHOLD_DAYS: 30
       # Log level for server, supported level NOTSET, DEBUG, INFO, WARN, ERROR, CRITICAL
@@ -76,7 +76,7 @@ services:
     environment:
       AGENT_SERVER_URL: ${AGENT_SERVER_URL:-http://agent-chain-server:8081}
       ANALYTICS_SERVER_URL: ${ANALYTICS_SERVER_URL:-http://analytics-server:8081}
-      REQUEST_TIMEOUT: 320 # with meta/llama-3.3-70b-instruct
+      REQUEST_TIMEOUT: 320 # with nvidia/nemotron-3-nano-30b-a3b
     restart: unless-stopped  # Optional: Automatically restart the container unless it is stopped
     depends_on:
     - agent-chain-server
@@ -105,7 +105,7 @@ services:
     command: --port 8081 --host 0.0.0.0 --workers 1
     environment:
       EXAMPLE_PATH: './src/analytics'
-      APP_LLM_MODELNAME: ${APP_LLM_MODELNAME:-"meta/llama-3.3-70b-instruct"}
+      APP_LLM_MODELNAME: ${APP_LLM_MODELNAME:-"nvidia/nemotron-3-nano-30b-a3b"}
       APP_LLM_MODELENGINE: nvidia-ai-endpoints
       APP_LLM_SERVERURL: ${APP_LLM_SERVERURL:-""}
       # Database name to store user conversation/summary
@@ -157,7 +157,7 @@ services:
       # Type of vectordb used to store embedding supported type milvus, pgvector
       APP_VECTORSTORE_NAME: "milvus"
       # url on which llm model is hosted. If "", Nvidia hosted API is used
-      APP_LLM_MODELNAME: ${APP_LLM_MODELNAME:-"meta/llama-3.3-70b-instruct"}
+      APP_LLM_MODELNAME: ${APP_LLM_MODELNAME:-"nvidia/nemotron-3-nano-30b-a3b"}
       # embedding model engine used for inference, supported type nvidia-ai-endpoints, huggingface
       APP_LLM_MODELENGINE: nvidia-ai-endpoints
       # url on which llm model is hosted. If "", Nvidia hosted API is used
@@ -207,7 +207,7 @@ services:
     command: --port 8081 --host 0.0.0.0 --workers 1
     environment:
       EXAMPLE_PATH: 'src/retrievers/structured_data'
-      APP_LLM_MODELNAME: ${APP_LLM_MODELNAME:-meta/llama-3.3-70b-instruct}
+      APP_LLM_MODELNAME: ${APP_LLM_MODELNAME:-nvidia/nemotron-3-nano-30b-a3b}
       APP_LLM_MODELENGINE: nvidia-ai-endpoints
       APP_LLM_SERVERURL: ${APP_LLM_SERVERURL:-""}
       APP_EMBEDDINGS_MODELNAME: ${APP_EMBEDDINGS_MODELNAME:-nvidia/llama-nemotron-embed-1b-v2}

--- a/notebooks/synthetic_data_generation.ipynb
+++ b/notebooks/synthetic_data_generation.ipynb
@@ -36,8 +36,7 @@
    "source": [
     "## Install requirements\n",
     "!pip install pandas\n",
-    "!pip install --upgrade --quiet langchain-nvidia-ai-endpoints\n",
-    "!pip install langchain"
+    "!pip install --upgrade --quiet langchain-core langchain-nvidia-ai-endpoints"
    ]
   },
   {
@@ -125,8 +124,7 @@
     "import random\n",
     "import getpass\n",
     "import os\n",
-    "import langchain\n",
-    "from langchain.prompts import PromptTemplate\n",
+    "from langchain_core.prompts import PromptTemplate\n",
     "\n",
     "from langchain_nvidia_ai_endpoints import ChatNVIDIA\n",
     "llm = ChatNVIDIA(model=\"nvidia/nemotron-4-340b-instruct\", temperature=1.0, max_tokens=2048)"

--- a/src/agent/requirements.txt
+++ b/src/agent/requirements.txt
@@ -12,5 +12,6 @@ prometheus_client==0.21.0
 bleach==6.1.0
 psycopg-pool==3.2.2
 langgraph-checkpoint-postgres==2.0.0
+psycopg==3.2.3
 psycopg-binary==3.2.3
 nest-asyncio==1.6.0

--- a/src/agent/requirements.txt
+++ b/src/agent/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.115.2
 uvicorn[standard]==0.27.1
 starlette==0.40.0
-langchain-nvidia-ai-endpoints==1.2.1
+langchain-nvidia-ai-endpoints==0.3.18
 dataclass-wizard==0.22.3
 langchain==0.3.0
 langgraph==0.2.32

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -87,6 +87,21 @@ FALLBACK_RESPONSES = [
     "Oops, that proved a tad difficult for me, can you retry with another question?"
 ]
 
+# Distinct fallback for rate-limit errors so users know to retry rather than rephrase.
+RATE_LIMIT_FALLBACK = (
+    "The model service is rate-limited right now. Please try again in a moment."
+)
+
+
+def _is_rate_limit_error(exc: BaseException) -> bool:
+    """Heuristic match for HTTP 429 surfaced by langchain_nvidia_ai_endpoints.
+
+    Upstream raises a bare Exception whose message includes the status code, so we
+    inspect the rendered message. Replace with isinstance once a typed exception lands.
+    """
+    msg = str(exc)
+    return "429" in msg or "Too Many Requests" in msg
+
 class Message(BaseModel):
     """Definition of the Chat Message type."""
     role: str = Field(description="Role for a message AI, User and System", default="user", max_length=256, pattern=r'[\s\S]*')
@@ -390,6 +405,7 @@ async def generate_answer(request: Request,
             try:
                 resp_id = str(uuid4())
                 is_exception = False
+                is_rate_limited = False
                 # Variable to track if this is the first yield
                 is_first_yield = True
                 resp_str = ""
@@ -511,11 +527,13 @@ async def generate_answer(request: Request,
                 logger.error(f"Sending empty response. Unexpected error in response_generator: {e}")
                 print_exc()
                 is_exception = True
+                is_rate_limited = _is_rate_limit_error(e)
 
             if is_exception:
                 logger.error("Sending back fallback responses since an exception was raised.")
                 is_exception = False
-                for data in fallback_response_generator(sentence=random.choice(FALLBACK_RESPONSES), session_id=prompt.session_id):
+                fallback_sentence = RATE_LIMIT_FALLBACK if is_rate_limited else random.choice(FALLBACK_RESPONSES)
+                for data in fallback_response_generator(sentence=fallback_sentence, session_id=prompt.session_id):
                     yield data
 
             chain_response = ChainResponse()

--- a/src/agent/utils.py
+++ b/src/agent/utils.py
@@ -43,56 +43,69 @@ default_llm_kwargs = {"temperature": 0, "top_p": 0.7, "max_tokens": 1024}
 canonical_rag_url = os.getenv('CANONICAL_RAG_URL', 'http://unstructured-retriever:8081')
 canonical_rag_search = f"{canonical_rag_url}/search"
 
+def _match_product_from_text(text: str, product_list) -> str:
+    """Deterministic substring match used as the robustness fallback when LLM extraction
+    is unavailable (rate-limit) or unreliable (model can't drive structured output).
+    Returns '' when no product's tokens match the text."""
+    if not text or not product_list:
+        return ''
+    text_lower = text.lower()
+    best, best_hits = '', 0
+    for product in product_list:
+        tokens = [t for t in re.split(r'\s+', product.lower()) if len(t) > 2 and t != 'nvidia']
+        if not tokens:
+            continue
+        hits = sum(1 for t in tokens if t in text_lower)
+        if hits > best_hits or (hits == best_hits and hits > 0 and len(product) > len(best)):
+            best, best_hits = product, hits
+    return best if best_hits > 0 else ''
+
+
 def get_product_name(messages, product_list) -> Dict:
-    """Given the user message and list of product find list of items which user might be talking about"""
+    """Given the user message and list of product find list of items which user might be talking about.
 
-    # First check product name in query
-    # If it's not in query, check in conversation
-    # Once the product name is known we will search for product name from database
-    # We will return product name from list and actual name detected.
-
-    llm = get_llm(**default_llm_kwargs)
+    Tries LLM-based structured extraction first; falls back to a deterministic substring
+    match against product_list so the agent stays functional when the LLM is rate-limited
+    or the model can't reliably emit structured output. Happy-path behavior is unchanged.
+    """
 
     class Product(BaseModel):
         name: str = Field(..., description="Name of the product talked about.")
 
-    prompt_text = prompts.get("get_product_name")["base_prompt"]
-    prompt = ChatPromptTemplate.from_messages(
-        [
-            ("system", prompt_text),
-        ]
-    )
-    llm = llm.with_structured_output(Product)
+    last_human_message = next((m.content for m in reversed(messages) if isinstance(m, HumanMessage)), None) or ""
+    product_name = None
 
-    chain = prompt | llm
-    # query to be used for document retrieval
-    # Get the last human message instead of messages[-2]
-    last_human_message = next((m.content for m in reversed(messages) if isinstance(m, HumanMessage)), None)
-    response = chain.invoke({"query": last_human_message})
+    # Happy path 1: LLM extracts the product name from the latest user message.
+    try:
+        prompt_text = prompts.get("get_product_name")["base_prompt"]
+        prompt = ChatPromptTemplate.from_messages([("system", prompt_text)])
+        llm = get_llm(**default_llm_kwargs).with_structured_output(Product)
+        response = (prompt | llm).invoke({"query": last_human_message})
+        if response is not None and getattr(response, "name", None) not in (None, "null"):
+            product_name = response.name
+    except Exception as exc:
+        logger.warning("LLM product extraction (query) failed; will try conversation/substring fallback: %s", exc)
 
-    product_name = response.name
+    # Happy path 2: LLM tries again over the full conversation when the first call yielded nothing.
+    if not product_name:
+        try:
+            fallback_prompt_text = prompts.get("get_product_name")["fallback_prompt"]
+            prompt = ChatPromptTemplate.from_messages([("system", fallback_prompt_text)])
+            llm = get_llm(**default_llm_kwargs).with_structured_output(Product)
+            response = (prompt | llm).invoke({"messages": messages})
+            if response is not None and getattr(response, "name", None) not in (None, "null"):
+                product_name = response.name
+        except Exception as exc:
+            logger.warning("LLM product extraction (conversation) failed; will try substring fallback: %s", exc)
 
-    # Check if product name is in query
-    if product_name == 'null':
+    # Robustness fallback: deterministic substring match against the known product list.
+    # Reached when both LLM calls were rate-limited, errored, or returned no usable name.
+    if not product_name:
+        product_name = _match_product_from_text(last_human_message, product_list)
+        if product_name:
+            logger.info("Substring-matched product from query text: %s", product_name)
 
-        # Check for produt name in user conversation
-        fallback_prompt_text = prompts.get("get_product_name")["fallback_prompt"]
-        prompt = ChatPromptTemplate.from_messages(
-            [
-                ("system", fallback_prompt_text),
-            ]
-        )
-
-        llm = get_llm(**default_llm_kwargs)
-        llm = llm.with_structured_output(Product)
-
-        chain = prompt | llm
-        # query to be used for document retrieval
-        response = chain.invoke({"messages": messages})
-
-        product_name = response.name
-    # Check if it's partial name exists or not
-    if product_name == 'null':
+    if not product_name:
         return {}
 
     def filter_products_by_name(name, products):

--- a/src/analytics/requirements.txt
+++ b/src/analytics/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.115.2
 uvicorn[standard]==0.27.1
 starlette==0.40.0
-langchain-nvidia-ai-endpoints==1.2.1
+langchain-nvidia-ai-endpoints==0.3.18
 langchain==0.3.0
 dataclass-wizard==0.22.3
 redis==5.0.8

--- a/src/common/configuration.py
+++ b/src/common/configuration.py
@@ -152,6 +152,11 @@ class LLMConfig(ConfigWizard):
         default="ai-mixtral-8x7b-instruct",
         help_txt="The name of the ai catalog model to be used with PandasAI agent",
     )
+    max_retries: int = configfield(
+        "max_retries",
+        default=3,
+        help_txt="Maximum attempts per LLM call before surfacing failure. Uses exponential backoff with jitter. Set to 1 to disable retries; useful primarily when the hosted endpoint rate-limits (HTTP 429).",
+    )
 
 @configclass
 class TextSplitterConfig(ConfigWizard):

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -45,6 +45,72 @@ except Exception as e:
     logger.error(f"Optional langchain API Catalog connector langchain_nvidia_ai_endpoints not installed.")
 
 try:
+    from tenacity import (
+        before_sleep_log,
+        retry,
+        retry_if_exception,
+        stop_after_attempt,
+        wait_exponential_jitter,
+    )
+except Exception:
+    logger.warning("tenacity not installed; LLM retry on transient errors will be disabled.")
+    retry = None  # type: ignore[assignment]
+
+
+def _is_transient_llm_error(exc: BaseException) -> bool:
+    """Return True for errors that should be retried.
+
+    langchain_nvidia_ai_endpoints raises a bare Exception whose message embeds
+    the HTTP status. Until upstream exposes a typed exception, we match on the
+    rendered message. We retry HTTP 429 (rate limit) and 5xx (transient server
+    errors); other errors (auth, validation) bubble up immediately.
+    """
+    msg = str(exc)
+    return any(
+        token in msg
+        for token in ("429", "Too Many Requests", "500", "502", "503", "504")
+    )
+
+
+# Read once at import time; respected at decorator-evaluation time. Default 3.
+_LLM_MAX_RETRIES = max(1, int(os.getenv("APP_LLM_MAX_RETRIES", "3")))
+
+
+if "ChatNVIDIA" in globals() and retry is not None:
+
+    class _RetryingChatNVIDIA(ChatNVIDIA):
+        """ChatNVIDIA that retries transient endpoint failures at the generate layer.
+
+        Decorating ``_generate`` / ``_agenerate`` ensures the retry survives
+        ``.bind_tools()`` and ``.with_structured_output()``, which strip
+        ``Runnable.with_retry()`` wrappers via attribute delegation. Retries
+        each model call individually so tool-calling agents don't compound
+        wait time across many graph steps.
+        """
+
+        @retry(
+            retry=retry_if_exception(_is_transient_llm_error),
+            stop=stop_after_attempt(_LLM_MAX_RETRIES),
+            wait=wait_exponential_jitter(initial=1, max=15),
+            before_sleep=before_sleep_log(logger, logging.WARNING),
+            reraise=True,
+        )
+        def _generate(self, *args, **kwargs):
+            return super()._generate(*args, **kwargs)
+
+        @retry(
+            retry=retry_if_exception(_is_transient_llm_error),
+            stop=stop_after_attempt(_LLM_MAX_RETRIES),
+            wait=wait_exponential_jitter(initial=1, max=15),
+            before_sleep=before_sleep_log(logger, logging.WARNING),
+            reraise=True,
+        )
+        async def _agenerate(self, *args, **kwargs):
+            return await super()._agenerate(*args, **kwargs)
+else:
+    _RetryingChatNVIDIA = ChatNVIDIA if "ChatNVIDIA" in globals() else None  # type: ignore[misc]
+
+try:
     from langchain_community.vectorstores import PGVector
     from langchain_community.vectorstores import Milvus
     from langchain_community.docstore.in_memory import InMemoryDocstore
@@ -175,16 +241,19 @@ def get_llm(**kwargs) -> LLM | SimpleChatModel:
         unused_params = [key for key in kwargs.keys() if key not in ['temperature', 'top_p', 'max_tokens']]
         if unused_params:
             logger.warning(f"The following parameters from kwargs are not supported: {unused_params} for {settings.llm.model_engine}")
+        # Retry transient endpoint failures (HTTP 429 / 5xx) at the _generate layer
+        # via _RetryingChatNVIDIA. Subclassing keeps the retry policy in effect after
+        # .bind_tools() / .with_structured_output(), which strip Runnable.with_retry().
         if settings.llm.server_url:
             logger.info(f"Using llm model {settings.llm.model_name} hosted at {settings.llm.server_url}")
-            return ChatNVIDIA(base_url=f"http://{settings.llm.server_url}/v1",
+            return _RetryingChatNVIDIA(base_url=f"http://{settings.llm.server_url}/v1",
                             model=settings.llm.model_name,
                             temperature = kwargs.get('temperature', None),
                             top_p = kwargs.get('top_p', None),
                             max_tokens = kwargs.get('max_tokens', None))
         else:
             logger.info(f"Using llm model {settings.llm.model_name} from api catalog")
-            return ChatNVIDIA(model=settings.llm.model_name,
+            return _RetryingChatNVIDIA(model=settings.llm.model_name,
                             temperature = kwargs.get('temperature', None),
                             top_p = kwargs.get('top_p', None),
                             max_tokens = kwargs.get('max_tokens', None))

--- a/src/retrievers/structured_data/requirements.txt
+++ b/src/retrievers/structured_data/requirements.txt
@@ -3,7 +3,7 @@ uvicorn[standard]==0.27.1
 starlette==0.40.0
 python-multipart==0.0.18
 langchain==0.3.0
-langchain-nvidia-ai-endpoints==1.2.1
+langchain-nvidia-ai-endpoints==0.3.18
 dataclass-wizard==0.22.3
 numexpr==2.9.0
 psycopg2-binary==2.9.9

--- a/src/retrievers/unstructured_data/chains.py
+++ b/src/retrievers/unstructured_data/chains.py
@@ -113,26 +113,32 @@ class UnstructuredRetriever(BaseExample):
             logger.info(f"Setting top k as: {top_k}.")
             retriever = vs.as_retriever(search_kwargs={"k": top_k}) # milvus does not support similarily threshold
 
-            # Invoke query rewriting to decontextualize the query before sending to retriever pipeline if conv history is passed
+            # Invoke query rewriting to decontextualize the query before sending to retriever pipeline if conv history is passed.
+            # Falls back to the original `content` (the latest user query) if the LLM is rate-limited or returns no structured output;
+            # retrieval still proceeds, just without conversational decontextualization.
             if conv_history:
                 class Question(BaseModel):
                     question: str = Field(..., description="A standalone question which can be understood without the chat history")
 
                 parsed_conv_history = [(msg.get("role"), msg.get("content")) for msg in conv_history]
                 default_llm_kwargs = {"temperature": 0.2, "top_p": 0.7, "max_tokens": 1024}
-                llm = get_llm(**default_llm_kwargs)
-                llm = llm.with_structured_output(Question)
-                query_rewriter_prompt = prompts.get("query_rewriting")
-                contextualize_q_prompt = ChatPromptTemplate.from_messages(
-                    [("system", query_rewriter_prompt), MessagesPlaceholder("chat_history"), ("human", "{input}"),]
-                )
-                q_prompt = contextualize_q_prompt | llm 
-                logger.info(f"Query rewriter prompt: {contextualize_q_prompt}")
-                response = q_prompt.invoke({"input": content, "chat_history": parsed_conv_history})
-                content = response.question
-                logger.info(f"Rewritten Query: {content}")
-                if content.replace('"', "'") == "''" or len(content) == 0:
-                    return []
+                try:
+                    llm = get_llm(**default_llm_kwargs).with_structured_output(Question)
+                    query_rewriter_prompt = prompts.get("query_rewriting")
+                    contextualize_q_prompt = ChatPromptTemplate.from_messages(
+                        [("system", query_rewriter_prompt), MessagesPlaceholder("chat_history"), ("human", "{input}"),]
+                    )
+                    q_prompt = contextualize_q_prompt | llm
+                    logger.info(f"Query rewriter prompt: {contextualize_q_prompt}")
+                    response = q_prompt.invoke({"input": content, "chat_history": parsed_conv_history})
+                    rewritten = getattr(response, "question", None) if response is not None else None
+                    if rewritten and len(rewritten.strip()) > 0 and rewritten.replace('"', "'") != "''":
+                        content = rewritten
+                        logger.info(f"Rewritten Query: {content}")
+                    else:
+                        logger.info("Query rewriter returned empty result; falling back to original query.")
+                except Exception as exc:
+                    logger.warning("LLM query rewriting failed; falling back to original query unchanged: %s", exc)
 
             if ranker:
                 logger.info(f"Narrowing the collection from {top_k} results and further narrowing it to {num_docs} with the reranker for rag chain.")

--- a/src/retrievers/unstructured_data/requirements.txt
+++ b/src/retrievers/unstructured_data/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.115.2
 uvicorn[standard]==0.27.1
 starlette==0.40.0
-langchain-nvidia-ai-endpoints==1.2.1
+langchain-nvidia-ai-endpoints==0.3.18
 dataclass-wizard==0.22.3
 nltk==3.9.1
 unstructured[all-docs]==0.12.5


### PR DESCRIPTION
## Summary
- Bump `langchain-nvidia-ai-endpoints` to 0.3.18 across the four backend services and pin `psycopg` for the agent image so source builds resolve.
- Default LLM swaps to `nvidia/nemotron-3-nano-30b-a3b`. Returns grounded responses in 6-10s per query against the hosted catalog and stays within free-tier quota under realistic single-user pacing.
- LLM calls retry transient endpoint failures (HTTP 429 / 5xx) via a `ChatNVIDIA` subclass decorating `_generate` / `_agenerate`. Subclassing keeps the retry policy in effect after `.bind_tools()` and `.with_structured_output()`, which strip `Runnable.with_retry()` via attribute delegation. Configurable via `APP_LLM_MAX_RETRIES` (default `3`).
- `get_product_name` and the unstructured retriever's query-rewriting step fall back to deterministic logic when their structured-output LLM call returns no usable response. Retrieval continues either way.
- Agent surfaces a rate-limit-specific message ("The model service is rate-limited right now. Please try again in a moment.") when retries exhaust, alongside the existing generic rephrase fallbacks.
- Deployment notebook's compose-up cell now passes `--build`; ingest-data notebook path is rendered as a clickable markdown link.

Scope: compose, requirements.txt across the 4 backend services, agent + unstructured-retriever source, deployment notebook, CHANGELOG.

Dep bumps (`ed08429`, `be74730`) authored by @jspaulding-nv and cherry-picked here. The default model choice originated on his `nemotron3-milvus-cpu` branch.

## Validation
Tested on a Brev `g4dn.xlarge` instance with the hosted NVIDIA AI catalog (no local model). Fresh `git clone` of this branch followed by the notebook's `docker compose up -d --build` produces a healthy stack. Sequential 4-query test ("Why was my GeForce RTX 4060 Ti order canceled?", 60s pacing) returns grounded responses with the actual order detail in 5-11s wall time per query, zero fallbacks, zero 429s reaching the user, zero graph timeouts.

Context: addresses partner-deployment issues hit during workshop preparation. Aware the blueprint is marked deprecated; landing these would help partners currently deploying it.

Signed-off-by: Steven Rick <srick@nvidia.com>